### PR TITLE
[DS] Create a typography component

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,10 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "tailwindCSS.experimental.classRegex": [
+    ["cn\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
+    ["tv\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
+    ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
+  ]
 }

--- a/packages/config/tailwind/index.js
+++ b/packages/config/tailwind/index.js
@@ -12,10 +12,10 @@ const config = {
       xl: ["1.25rem", { lineHeight: "1.875rem" }], // 20px - text xl
       "2xl": ["1.5rem", { lineHeight: "2rem" }], // 24px - display xs
       "3xl": ["1.875rem", { lineHeight: "2.375rem" }], // 30px - display sm
-      "4xl": ["2.25rem", { lineHeight: "2.75rem", letterSpacing: "-2%" }], // 36px - display base
-      "5xl": ["3rem", { lineHeight: "3.75rem", letterSpacing: "-2%" }], // 48px - display lg
-      "6xl": ["3.75rem", { lineHeight: "4.5rem", letterSpacing: "-2%" }], // 60px - display xl
-      "7xl": ["4.5rem", { lineHeight: "5.625rem", letterSpacing: "-2%" }], // 72px - display 2xl
+      "4xl": ["2.25rem", { lineHeight: "2.75rem", letterSpacing: "-0.02em" }], // 36px - display base
+      "5xl": ["3rem", { lineHeight: "3.75rem", letterSpacing: "-0.02em" }], // 48px - display lg
+      "6xl": ["3.75rem", { lineHeight: "4.5rem", letterSpacing: "-0.02em" }], // 60px - display xl
+      "7xl": ["4.5rem", { lineHeight: "5.625rem", letterSpacing: "-0.02em" }], // 72px - display 2xl
     },
     colors: {
       white: "#ffffff",

--- a/packages/design-system/react/src/components/Typography/Typography.tsx
+++ b/packages/design-system/react/src/components/Typography/Typography.tsx
@@ -1,0 +1,52 @@
+import { forwardRef, type ElementRef, type Ref } from "react";
+
+import { cn } from "@myapp/utils";
+
+import {
+  typographyVariants,
+  type TypographyVariants,
+} from "./Typography.variants";
+
+type TypographyType = "p" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
+export type TypographyProps<T extends TypographyType> = {
+  as?: T;
+  // eslint-disable-next-line no-undef
+} & JSX.IntrinsicElements[T] &
+  TypographyVariants;
+
+type DefaultProps = {
+  as: "p";
+  // eslint-disable-next-line no-undef
+} & JSX.IntrinsicElements["p"] &
+  TypographyVariants;
+
+type RefFor<T extends TypographyType> = ElementRef<T>;
+
+const Typography = forwardRef(
+  <T extends TypographyType = "p">(
+    {
+      as: Tag = "p",
+      className,
+      children,
+      size = "text-md",
+      ...props
+    }: TypographyProps<T> | DefaultProps,
+    ref: Ref<RefFor<T>>,
+  ) => {
+    return (
+      <Tag
+        className={cn(typographyVariants({ size }), className)}
+        {...props}
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+        ref={ref as any}
+      >
+        {children}
+      </Tag>
+    );
+  },
+);
+
+Typography.displayName = "Typography";
+
+export { Typography };

--- a/packages/design-system/react/src/components/Typography/Typography.variants.ts
+++ b/packages/design-system/react/src/components/Typography/Typography.variants.ts
@@ -1,0 +1,25 @@
+import { tv, type VariantProps } from "tailwind-variants";
+
+export const typographyVariants = tv({
+  base: ["font-sans not-italic font-normal text-gray-900"],
+  variants: {
+    size: {
+      "display-2xl": ["text-7xl"],
+      "display-xl": ["text-6xl"],
+      "display-lg": ["text-5xl"],
+      "display-md": ["text-4xl"],
+      "display-sm": ["text-3xl"],
+      "display-xs": ["text-2xl"],
+      "text-xl": ["text-xl"],
+      "text-lg": ["text-lg"],
+      "text-md": ["text-base"],
+      "text-sm": ["text-sm"],
+      "text-xs": ["text-xs"],
+    },
+  },
+  defaultVariants: {
+    size: "text-md",
+  },
+});
+
+export type TypographyVariants = VariantProps<typeof typographyVariants>;

--- a/packages/design-system/react/src/components/Typography/index.ts
+++ b/packages/design-system/react/src/components/Typography/index.ts
@@ -1,0 +1,1 @@
+export * from "./Typography";

--- a/packages/design-system/react/src/index.tsx
+++ b/packages/design-system/react/src/index.tsx
@@ -1,3 +1,4 @@
 import "./styles.css";
 
 export * from "./components/Button";
+export * from "./components/Typography";


### PR DESCRIPTION
## Description

I have created a typography component based on issue #6. Change the requirement regarding the props of the component. Currently, we only have one prop that can define the size of the component. The name of the props is `size` and we can directly choose which type of typography we want to show like `text` or `display`. 

Here is an example:
```javascript
<Typography as="h1" size="display-2xl">This is a header</Typography>
<Typography>This is a paragraph</Typography>
```